### PR TITLE
Use rubber, since pdflatex needs serveral runs

### DIFF
--- a/slideware/Makefile
+++ b/slideware/Makefile
@@ -1,8 +1,15 @@
 OUT_DIR = out
+
 VIEWER ?= evince $(VIEWER_OPTS)
+
 LATEX_OPTS = --shell-escape
-#LAYEX_OPTS += --interaction=nonstopmode
 LATEX_OPTS += --interaction=batchmode
+
+SVGTOLATEX ?= inkscape
+SVGTOLATEX_OPTS ?= -z --export-latex
+SVGTOLATEX_IN ?= --file=
+SVGTOLATEX_OUT ?= --export-pdf=
+
 VPATH = .:./$(OUT_DIR)
 
 all: pdf
@@ -10,28 +17,33 @@ all: pdf
 # Specific view targets goes here
 
 view-intro: pdf
-	$(VIEWER) $(wildcard $(OUT_DIR)/intro/*.pdf)
+	$(VIEWER) $(OUT_DIR)/intro/intro.pdf
 
 view-sample: pdf
-	$(VIEWER) $(wildcard $(OUT_DIR)/sample/*.pdf)
+	$(VIEWER) $(OUT_DIR)/sample/presentation_1.pdf
 
 # ---
 
 view: pdf
 	$(VIEWER) $(wildcard $(OUT_DIR)/*/*.pdf)
 
-pdf: $(addsuffix .pdf, $(basename $(wildcard */*.tex)))
+svg: $(addsuffix .pdf_tex, $(basename $(wildcard */*.svg)))
+pdf: svg $(addsuffix .pdf, $(basename $(wildcard */*.tex)))
+
+
+%.pdf_tex: %.svg
+	$(eval DIR=$(dir $?))
+	$(eval TARGET=$(addsuffix .pdf, $(basename $@)))
+	@echo "* Processing $?"
+	@mkdir -p $(OUT_DIR)/$(DIR)
+	@$(SVGTOLATEX) $(SVGTOLATEX_OPTS) $(SVGTOLATEX_IN)$< $(SVGTOLATEX_OUT)$(OUT_DIR)/$(TARGET) >/dev/null 2>&1
 
 %.pdf: %.tex
 	$(eval DIR=$(dir $?))
 	$(eval FILE=$(patsubst $(DIR)%,%, $?))
 	@echo "* Processing $?"
 	@mkdir -p $(OUT_DIR)/$(DIR)
-	@cd $(DIR) && pdflatex $(LATEX_OPTS) --output-directory=../$(OUT_DIR)/$(DIR) $(FILE) 
+	@rubber --pdf --into $(OUT_DIR)/$(DIR) $?
 
-clean_files: $(wildcard */*.pdf) $(wildcard */*.pdf_tex)
-	rm $?
-
-clean: clean_files
-	rm -r $(OUT_DIR)
-
+clean:
+	@test -d $(OUT_DIR) && rm -r $(OUT_DIR) || echo "Nothing to do"


### PR DESCRIPTION
Due to the change to rubber we had to generate
our own graphics using inkscape.

This simplified things since all output is now in
the same directory ;)