### PR TITLE
Make multiple tex/svg levels possible

### DIFF
--- a/slideware/Makefile
+++ b/slideware/Makefile
@@ -33,8 +33,8 @@ view-sample: pdf
 view: pdf
 	$(VIEWER) $(wildcard $(OUT_DIR)/*/*.pdf)
 
-svg: $(addsuffix .pdf, $(basename $(wildcard */*.svg)))
-pdf: svg $(addsuffix .pdf, $(basename $(wildcard */*.tex)))
+svg: $(addsuffix .pdf, $(basename $(shell find ./ -type f -name *.svg)))
+pdf: svg $(addsuffix .pdf, $(basename $(shell find ./ -type f -name *.tex)))
 
 
 %.pdf: %.svg


### PR DESCRIPTION
While I'm not really proud of the solution (there should be a ** match
in wildcard that does the same thing... it didn't work so... )

The makefile now handles structured directories with multiple levels
to make the output a bit more managable ie, main pdf could be the
only file in out/page/*.pdf and all other generated and included files
would be in subdirectories.