### PR TITLE
fix directory name for the gpio driver

### DIFF
--- a/exercises/devicedriver.txt
+++ b/exercises/devicedriver.txt
@@ -1,7 +1,7 @@
 Device driver fundamentals: probing and interrupts
 ==================================================
 
-The code and the device tree overlay is located in gpio-led-module/
+The code and the device tree overlay is located in exercises/led-gpio-key-module/
 
 0. Preparations
 ---------------


### PR DESCRIPTION
the name in the exercise description does not match the one in the file system